### PR TITLE
Unfix allowed versions, so that it can work using rails 6

### DIFF
--- a/scrollto-rails.gemspec
+++ b/scrollto-rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", "~> 5.0"
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_dependency "railties", "> 5.0"
+  spec.add_development_dependency "bundler", "> 1.13"
+  spec.add_development_dependency "rake", "> 10.0"
 end


### PR DESCRIPTION
In order to be able to use this gem with Rails 6, it is necessary to allow it to use newer versions of the railties.